### PR TITLE
Upgrade argonaut dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "purescript-uint": "^5.1.0",
     "purescript-unordered-collections": "^1.6.0",
-    "purescript-argonaut": "^6.0.0",
+    "purescript-argonaut": "^7.0.0",
     "purescript-quickcheck": "^6.1.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -121,12 +121,7 @@ let additions =
 let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
-let overrides =
-      { argonaut = upstream.argonaut // { version = "v7.0.0" }
-      , argonaut-codecs = upstream.argonaut-codecs // { version = "v7.0.0" }
-      , argonaut-traversals =
-          upstream.argonaut-traversals // { version = "v8.0.0" }
-      }
+let overrides = {=}
 
 let additions = {=}
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -119,9 +119,14 @@ let additions =
 
 
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200423/packages.dhall sha256:c180a06bb5444fd950f8cbdd6605c644fd246deb397e62572b8f4a6b9dbcaf22
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
-let overrides = {=}
+let overrides =
+      { argonaut = upstream.argonaut // { version = "v7.0.0" }
+      , argonaut-codecs = upstream.argonaut-codecs // { version = "v7.0.0" }
+      , argonaut-traversals =
+          upstream.argonaut-traversals // { version = "v8.0.0" }
+      }
 
 let additions = {=}
 


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors. This PR updates the Bower dependencies for this library (and upgrades the package set for good measure).

Fortunately, this library builds with both versions of Argonaut without code changes, so it's not necessary to update anything for this to remain compatible with the next version of the package sets. Still, Bower users will need the new release to stay compatible.

Sorry for the hassle! Thanks!